### PR TITLE
Fix npm install/build issue with latest vsce

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-slim
+FROM node:16-slim
 
 RUN npm i -g vsce
 


### PR DESCRIPTION
Upgrade base image to latest LTS `node:16-slim`.