### PR TITLE
chore: vsce package has been renamed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16-slim
 
-RUN npm i -g vsce
+RUN npm i -g @vscode/vsce
 
 COPY "entrypoint.sh" "/entrypoint.sh"
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Hi the `vsce` npm package is deprecated has been renamed to `@vscode/vsce`
See: 
- https://www.npmjs.com/package/vsce
- https://github.com/microsoft/vscode-vsce#usage

this PR will switch to the new package name